### PR TITLE
deploy via fly.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.14.1
-EXPOSE 8080
+FROM golang:1.14.1 as builder
 WORKDIR /go/src/vvgo
 COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o vvgo
 
-RUN go install -v ./...
-
-CMD ["vvgo"]
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+COPY --from=builder /go/src/vvgo .
+EXPOSE 8080
+CMD ["/vvgo"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,6 +1,9 @@
 app = "vvgo"
 
 
+[build]
+  builder = "cloudfoundry/cnb:tiny"
+
 [[services]]
   internal_port = 8080
   protocol = "tcp"
@@ -19,4 +22,11 @@ app = "vvgo"
 
   [[services.tcp_checks]]
     interval = 10000
+    timeout = 2000
+
+  [[services.http_checks]]
+    interval = 10000
+    method = "get"
+    path = "/"
+    protocol = "http"
     timeout = 2000

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,22 @@
+app = "vvgo"
+
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = "80"
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = "443"
+
+  [[services.tcp_checks]]
+    interval = 10000
+    timeout = 2000


### PR DESCRIPTION
Lets use fly.io for deploys!

Also cleans up the docker build to use a builder image. That's a neat feature.