### PR TITLE
inject version meta at build time and serve via http

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,16 +38,9 @@ jobs:
           set -x
           IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=${{ github.sha }}
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          docker tag builder $IMAGE_ID:$VERSION-builder
-          docker tag artifact $IMAGE_ID:$VERSION
-          docker tag artifact $IMAGE_ID:${{ github.head_ref }}
-          docker tag artifact $IMAGE_ID:${{ github.head_ref }}-$VERSION
-          docker push $IMAGE_ID:$VERSION-builder
-          docker push $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:${{ github.head_ref }}
-          docker push $IMAGE_ID:${{ github.head_ref }}-$VERSION
+          for tag in $(docker run --rm artifact --release-tags); do
+              docker tag builder $IMAGE_ID:$tag-builder
+              docker tag artifact $IMAGE_ID:$tag
+              docker push $IMAGE_ID:$tag-builder
+              docker push $IMAGE_ID:$tag
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vvgo
 .idea
+info.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.14.1 as builder
 WORKDIR /go/src/vvgo
 COPY . .
 RUN go mod download
+RUN go generate
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /go/bin/vvgo
 
 FROM builder as tester
@@ -13,3 +14,4 @@ COPY --from=builder /go/bin/vvgo /vvgo
 COPY --from=builder /go/src/vvgo/public /public
 EXPOSE 8080
 CMD ["/vvgo"]
+ENTRYPOINT ["/vvgo"]

--- a/api_server.go
+++ b/api_server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/minio/minio-go/v6"
 	"github.com/sirupsen/logrus"
+	"github.com/virtual-vgo/vvgo/pkg/version"
 	"html/template"
 	"io"
 	"net"
@@ -46,6 +47,7 @@ func NewApiServer(store ObjectStore, config ApiServerConfig) *ApiServer {
 	server.Handle("/sheets", auth.Authenticate(server.SheetsIndex))
 	server.Handle("/sheets/upload", auth.Authenticate(server.SheetsUpload))
 	server.Handle("/download", auth.Authenticate(server.Download))
+	server.Handle("/version", APIHandlerFunc(server.Version))
 	server.Handle("/", http.FileServer(http.Dir("public")))
 	return &server
 }
@@ -291,6 +293,25 @@ func (x *ApiServer) Download(w http.ResponseWriter, r *http.Request) {
 	default:
 		logger.WithError(err).Error("minio.StatObject() failed")
 		http.Error(w, "", http.StatusInternalServerError)
+	}
+}
+
+func (x ApiServer) Version(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "", http.StatusMethodNotAllowed)
+		return
+	}
+
+	versionHeader := version.Header()
+	for k := range versionHeader {
+		w.Header().Set(k, versionHeader.Get(k))
+	}
+
+	switch true {
+	case acceptsType(r, "application/json"):
+		w.Write(version.JSON())
+	default:
+		w.Write([]byte(version.String()))
 	}
 }
 

--- a/api_server_test.go
+++ b/api_server_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"github.com/minio/minio-go/v6"
 	"golang.org/x/net/html"
@@ -595,6 +596,36 @@ func TestSheet_ToTags(t *testing.T) {
 	if expected, got := fmt.Sprintf("%#v", wantMap), fmt.Sprintf("%#v", gotMap); expected != got {
 		t.Errorf("expected %v, got %v", expected, got)
 	}
+}
+
+func TestApiServer_Version(t *testing.T) {
+	t.Run("accept:application/json", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/version", strings.NewReader(""))
+		req.Header.Set("Accept", "application/json")
+		apiServer := NewApiServer(MockObjectStore{}, ApiServerConfig{})
+		apiServer.ServeHTTP(recorder, req)
+
+		if expected, got := http.StatusOK, recorder.Code; expected != got {
+			t.Errorf("expected code %v, got %v", expected, got)
+		}
+		var gotJSON json.RawMessage
+		if err := json.NewDecoder(recorder.Body).Decode(&gotJSON); err != nil {
+			t.Errorf("json.Decode() failed: %v", err)
+		}
+
+	})
+	t.Run("accept:text/html", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/version", strings.NewReader(""))
+		req.Header.Set("Accept", "text/html")
+
+		apiServer := NewApiServer(MockObjectStore{}, ApiServerConfig{})
+		apiServer.ServeHTTP(recorder, req)
+		if expected, got := http.StatusOK, recorder.Code; expected != got {
+			t.Errorf("expected code %v, got %v", expected, got)
+		}
+	})
 }
 
 func TestNewSheetFromTags(t *testing.T) {

--- a/api_server_test.go
+++ b/api_server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/minio/minio-go/v6"
+	"github.com/virtual-vgo/vvgo/pkg/version"
 	"golang.org/x/net/html"
 	"io"
 	"io/ioutil"
@@ -623,6 +624,9 @@ func TestApiServer_Version(t *testing.T) {
 		apiServer := NewApiServer(MockObjectStore{}, ApiServerConfig{})
 		apiServer.ServeHTTP(recorder, req)
 		if expected, got := http.StatusOK, recorder.Code; expected != got {
+			t.Errorf("expected code %v, got %v", expected, got)
+		}
+		if expected, got := version.String(), recorder.Body.String(); expected != got {
 			t.Errorf("expected code %v, got %v", expected, got)
 		}
 	})

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,55 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+// Package to query version information
+
+var (
+	version Version
+	setOnce sync.Once
+)
+
+func Set(ver Version)       { setOnce.Do(func() { version = ver }) }
+func String() string        { return version.String() }
+func JSON() json.RawMessage { return version.JSON() }
+func Header() http.Header   { return version.Header() }
+func ReleaseTags() []string { return version.ReleaseTags() }
+
+type Version struct {
+	BuildHost string `json:"build_host"`
+	BuildTime string `json:"build_time"`
+	GitSha    string `json:"git_sha"`
+	GitBranch string `json:"git_branch"`
+	GoVersion string `json:"go_version"`
+}
+
+func (x Version) String() string {
+	return fmt.Sprintf("%s-%s", x.GitBranch, x.GitSha)
+}
+
+func (x Version) JSON() json.RawMessage {
+	jsonBytes, _ := json.Marshal(x)
+	return jsonBytes
+}
+
+func (x Version) Header() http.Header {
+	header := make(http.Header)
+	header.Set("Build-Host", x.BuildHost)
+	header.Set("Build-Time", x.BuildTime)
+	header.Set("Git-Sha", x.GitSha)
+	header.Set("Git-Branch", x.GitBranch)
+	header.Set("Go-Version", x.GoVersion)
+	return header
+}
+
+func (x Version) ReleaseTags() []string {
+	return []string{
+		x.GitBranch,
+		fmt.Sprintf("%s-%s", x.GitBranch, x.GitSha),
+	}
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,95 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestHeader(t *testing.T) {
+	version = Version{
+		BuildHost: "tuba-international.xyz",
+		BuildTime: "today",
+		GitSha:    "yeet",
+		GitBranch: "best-branch",
+		GoVersion: "1.14.1",
+	}
+	wantHeader := http.Header{
+		"Build-Host": []string{"tuba-international.xyz"},
+		"Build-Time": []string{"today"},
+		"Git-Sha":    []string{"yeet"},
+		"Git-Branch": []string{"best-branch"},
+		"Go-Version": []string{"1.14.1"},
+	}
+	gotHeader := Header()
+
+	if expected, got := headerToString(wantHeader), headerToString(gotHeader); expected != got {
+		t.Errorf("\nwant: `%v`\n got: `%v`", expected, got)
+	}
+}
+
+func headerToString(header http.Header) string {
+	var buf bytes.Buffer
+	header.Write(&buf)
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}
+
+func TestJSON(t *testing.T) {
+	version = Version{
+		BuildHost: "tuba-international.xyz",
+		BuildTime: "today",
+		GitSha:    "yeet",
+		GitBranch: "best-branch",
+		GoVersion: "1.14.1",
+	}
+	wantJSON := `{"build_host":"tuba-international.xyz","build_time":"today","git_sha":"yeet","git_branch":"best-branch","go_version":"1.14.1"}`
+	gotJSON := string(JSON())
+	if expected, got := wantJSON, gotJSON; expected != got {
+		t.Errorf("\nwant: `%v`\n got: `%v`", expected, got)
+	}
+}
+
+func TestSet(t *testing.T) {
+	version = Version{} // reset
+	Set(Version{
+		BuildHost: "tuba-international.xyz",
+		BuildTime: "today",
+		GitSha:    "yeet",
+		GitBranch: "best-branch",
+		GoVersion: "1.14.1",
+	})
+
+	wantVersion := Version{
+		BuildHost: "tuba-international.xyz",
+		BuildTime: "today",
+		GitSha:    "yeet",
+		GitBranch: "best-branch",
+		GoVersion: "1.14.1",
+	}
+	gotVersion := version
+
+	if expected, got := fmt.Sprintf("%#v", wantVersion), fmt.Sprintf("%#v", gotVersion); expected != got {
+		t.Errorf("\nwant: `%v`\n got: `%v`", expected, got)
+	}
+}
+
+func TestString(t *testing.T) {
+	version = Version{
+		BuildHost: "tuba-international.xyz",
+		BuildTime: "today",
+		GitSha:    "yeet",
+		GitBranch: "best-branch",
+		GoVersion: "1.14.1",
+	}
+	wantString := "best-branch-yeet"
+	gotString := String()
+
+	if expected, got := wantString, gotString; expected != got {
+		t.Errorf("\nwant: `%v`\n got: `%v`", expected, got)
+	}
+}

--- a/tools/version/main.go
+++ b/tools/version/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"github.com/virtual-vgo/vvgo/pkg/version"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"text/template"
+	"time"
+)
+
+var infoTemplate = template.Must(template.New("info.go").Parse(`
+package main
+
+import "github.com/virtual-vgo/vvgo/pkg/version"
+
+func init() {
+ 	version.Set(version.Version{
+		BuildHost: "{{ .BuildHost }}",
+		BuildTime: "{{ .BuildTime }}",
+		GitSha:    "{{ .GitSha }}",
+		GitBranch: "{{ .GitBranch }}",
+		GoVersion: "{{ .GoVersion }}",
+	})
+}`))
+
+func main() {
+	ver := version.Version{
+		BuildHost: hostname(),
+		BuildTime: time.Now().String(),
+		GitSha:    gitSha(),
+		GitBranch: gitBranch(),
+		GoVersion: runtime.Version(),
+	}
+	os.Remove("info.go")
+	output, err := os.OpenFile("info.go", os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		panic(err)
+	}
+	defer output.Close()
+	writeVersion(output, ver)
+}
+
+func hostname() string {
+	host, err := os.Hostname()
+	if err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(host)
+}
+
+func gitSha() string {
+	output, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "command `git rev-parse HEAD` failed!")
+		panic(err)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func gitBranch() string {
+	output, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "command `git rev-parse --abbrev-ref HEAD` failed!")
+		panic(err)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// writes the info to the io writer
+// output is passed through gofmt
+func writeVersion(output io.Writer, ver version.Version) {
+	if err := func() error {
+		// use gofmt to actually write the file
+		gofmt := exec.Command("gofmt")
+		gofmt.Stdout = output
+		gofmt.Stderr = os.Stderr
+
+		// make an input pipe for gofmt
+		gofmtIn, err := gofmt.StdinPipe()
+		if err != nil {
+			return fmt.Errorf("cmd.StdinPipe() failed: %v", err)
+		}
+
+		// start gofmt
+		err = gofmt.Start()
+		if err != nil {
+			return fmt.Errorf("cmd.Start() failed: %v", err)
+		}
+
+		// run the template
+		err = infoTemplate.Execute(gofmtIn, ver)
+		if err != nil {
+			return fmt.Errorf("template.Execute() failed: %v", err)
+		}
+
+		// close the input pipe
+		if err = gofmtIn.Close(); err != nil {
+			return fmt.Errorf("gofmtIn.Close() failed: %v", err)
+		}
+
+		// check that gofmt exits success
+		if err = gofmt.Wait(); err != nil {
+			return fmt.Errorf("cmd.Wait() failed: %v", err)
+		}
+		return nil
+	}(); err != nil {
+		panic(err)
+	}
+}

--- a/vvgo.go
+++ b/vvgo.go
@@ -26,8 +26,6 @@ var logger = &logrus.Logger{
 	ReportCaller: false,
 }
 
-var ver version.Version
-
 type Config struct {
 	Minio MinioConfig
 	Api   ApiServerConfig

--- a/vvgo.go
+++ b/vvgo.go
@@ -1,7 +1,12 @@
+//go:generate go run github.com/virtual-vgo/vvgo/tools/version
+
 package main
 
 import (
+	"flag"
+	"fmt"
 	"github.com/sirupsen/logrus"
+	"github.com/virtual-vgo/vvgo/pkg/version"
 	"net/http"
 	"os"
 	"strconv"
@@ -20,6 +25,8 @@ var logger = &logrus.Logger{
 	ExitFunc:     os.Exit,
 	ReportCaller: false,
 }
+
+var ver version.Version
 
 type Config struct {
 	Minio MinioConfig
@@ -66,9 +73,22 @@ func (x *Config) ParseEnv() {
 	}
 }
 
+func (x Config) ParseFlags() {
+	var showReleaseTags bool
+	flag.BoolVar(&showReleaseTags, "release-tags", false, "show release tags and quit")
+	flag.Parse()
+	if showReleaseTags {
+		for _, tag := range version.ReleaseTags() {
+			fmt.Fprintf(os.Stdout, "%s\n", tag)
+		}
+		os.Exit(0)
+	}
+}
+
 func main() {
 	config := NewDefaultConfig()
 	config.ParseEnv()
+	config.ParseFlags()
 
 	apiServer := NewApiServer(
 		NewMinioDriverMust(config.Minio),


### PR DESCRIPTION
Version info is generated via go generate
`go run github.com/virtual-vgo/vvg/tools/version` generates the info.go file. This file is compiled into the main binary.

Version is served via vvgo.org/version and can return application/json

I also added a flag to vvgo so it can generate the release tags used by github actions.
