### PR TITLE
Fix build workflow caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
       - name: Build image
         run: |
           CACHE_FROM=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
@@ -28,9 +32,6 @@ jobs:
             --cache-from=$CACHE_FROM:latest-builder \
             --cache-from=$CACHE_FROM:latest \
             --tag artifact
-
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         shell: bash


### PR DESCRIPTION
Reordered steps so that we log in to the repository before attempting a pull.

This should speed up builds.