### PR TITLE
Use Docker's BuildKit cache mount for dep builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Build image
+        env:
+          DOCKER_BUILDKIT: 1
         run: |
           CACHE_FROM=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
 


### PR DESCRIPTION
This speeds up builds, hopefully.