### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-vvgo.org


### PR DESCRIPTION
This was used for gihub pages, but we no longer need it.