### PR TITLE
Add new VVGO social media icons

### DIFF
--- a/pkg/api/testdata/backups.html
+++ b/pkg/api/testdata/backups.html
@@ -91,15 +91,29 @@
 <footer class="footer">
     <div class="container mt-3 text-center">
         <div class="row-cols-1">
-            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
-                <i class="fab fa-facebook-square fa-2x"></i>
-            </a>
-            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
-                <i class="fab fa-github-square fa-2x"></i>
-            </a>
             <a class="text-light"
                href="https://www.youtube.com/channel/UCeipEtsfjAA_8ATsd7SNAaQ">
-                <i class="fab fa-youtube-square fa-2x"></i>
+                <i class="fab fa-youtube fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
+                <i class="fab fa-facebook fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://vvgo.bandcamp.com/">
+                <i class="fab fa-bandcamp fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
+                <i class="fab fa-github fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://www.instagram.com/virtualvgo/">
+                <i class="fab fa-instagram fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://twitter.com/virtualvgo">
+                <i class="fab fa-twitter fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://discord.com/invite/9RVUJMQ">
+                <i class="fab fa-discord fa-2x"></i>
             </a>
         </div>
         <div class="row-cols-1">

--- a/pkg/api/testdata/index.html
+++ b/pkg/api/testdata/index.html
@@ -60,15 +60,29 @@
 <footer class="footer">
     <div class="container mt-3 text-center">
         <div class="row-cols-1">
-            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
-                <i class="fab fa-facebook-square fa-2x"></i>
-            </a>
-            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
-                <i class="fab fa-github-square fa-2x"></i>
-            </a>
             <a class="text-light"
                href="https://www.youtube.com/channel/UCeipEtsfjAA_8ATsd7SNAaQ">
-                <i class="fab fa-youtube-square fa-2x"></i>
+                <i class="fab fa-youtube fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
+                <i class="fab fa-facebook fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://vvgo.bandcamp.com/">
+                <i class="fab fa-bandcamp fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
+                <i class="fab fa-github fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://www.instagram.com/virtualvgo/">
+                <i class="fab fa-instagram fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://twitter.com/virtualvgo">
+                <i class="fab fa-twitter fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://discord.com/invite/9RVUJMQ">
+                <i class="fab fa-discord fa-2x"></i>
             </a>
         </div>
         <div class="row-cols-1">

--- a/pkg/api/testdata/login.html
+++ b/pkg/api/testdata/login.html
@@ -61,15 +61,29 @@
 <footer class="footer">
     <div class="container mt-3 text-center">
         <div class="row-cols-1">
-            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
-                <i class="fab fa-facebook-square fa-2x"></i>
-            </a>
-            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
-                <i class="fab fa-github-square fa-2x"></i>
-            </a>
             <a class="text-light"
                href="https://www.youtube.com/channel/UCeipEtsfjAA_8ATsd7SNAaQ">
-                <i class="fab fa-youtube-square fa-2x"></i>
+                <i class="fab fa-youtube fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
+                <i class="fab fa-facebook fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://vvgo.bandcamp.com/">
+                <i class="fab fa-bandcamp fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
+                <i class="fab fa-github fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://www.instagram.com/virtualvgo/">
+                <i class="fab fa-instagram fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://twitter.com/virtualvgo">
+                <i class="fab fa-twitter fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://discord.com/invite/9RVUJMQ">
+                <i class="fab fa-discord fa-2x"></i>
             </a>
         </div>
         <div class="row-cols-1">

--- a/pkg/api/testdata/parts.html
+++ b/pkg/api/testdata/parts.html
@@ -91,15 +91,29 @@
 <footer class="footer">
     <div class="container mt-3 text-center">
         <div class="row-cols-1">
-            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
-                <i class="fab fa-facebook-square fa-2x"></i>
-            </a>
-            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
-                <i class="fab fa-github-square fa-2x"></i>
-            </a>
             <a class="text-light"
                href="https://www.youtube.com/channel/UCeipEtsfjAA_8ATsd7SNAaQ">
-                <i class="fab fa-youtube-square fa-2x"></i>
+                <i class="fab fa-youtube fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
+                <i class="fab fa-facebook fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://vvgo.bandcamp.com/">
+                <i class="fab fa-bandcamp fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
+                <i class="fab fa-github fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://www.instagram.com/virtualvgo/">
+                <i class="fab fa-instagram fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://twitter.com/virtualvgo">
+                <i class="fab fa-twitter fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://discord.com/invite/9RVUJMQ">
+                <i class="fab fa-discord fa-2x"></i>
             </a>
         </div>
         <div class="row-cols-1">

--- a/public/footer.gohtml
+++ b/public/footer.gohtml
@@ -1,15 +1,26 @@
 <footer class="footer">
     <div class="container mt-3 text-center">
         <div class="row-cols-1">
-            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
-                <i class="fab fa-facebook-square fa-2x"></i>
-            </a>
-            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
-                <i class="fab fa-github-square fa-2x"></i>
-            </a>
             <a class="text-light"
                href="https://www.youtube.com/channel/UCeipEtsfjAA_8ATsd7SNAaQ">
-                <i class="fab fa-youtube-square fa-2x"></i>
+                <i class="fab fa-youtube fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://www.facebook.com/groups/1080154885682377/">
+                <i class="fab fa-facebook fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://vvgo.bandcamp.com/">
+                <i class="fab fa-bandcamp fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://github.com/virtual-vgo/vvgo">
+                <i class="fab fa-github fa-2x"></i>
+            </a>
+            <a class="text-light"
+               href="https://www.instagram.com/virtualvgo/">
+                <i class="fab fa-instagram fa-2x"></i>
+            </a>
+            <a class="text-light" href="https://discord.com/invite/9RVUJMQ">
+                <i class="fab fa-discord fa-2x"></i>
             </a>
         </div>
         <div class="row-cols-1">

--- a/public/footer.gohtml
+++ b/public/footer.gohtml
@@ -19,6 +19,9 @@
                href="https://www.instagram.com/virtualvgo/">
                 <i class="fab fa-instagram fa-2x"></i>
             </a>
+            <a class="text-light" href="https://twitter.com/virtualvgo">
+                <i class="fab fa-twitter fa-2x"></i>
+            </a>
             <a class="text-light" href="https://discord.com/invite/9RVUJMQ">
                 <i class="fab fa-discord fa-2x"></i>
             </a>


### PR DESCRIPTION
Adds Discord, Instagram, Twitter, and Bandcamp social icons to the footer (addresses #184 and #159).

Icon style was switched away from the square version because the FontAwesome icons for Bandcamp and Discord have a square version to match the other icons, and ordering was tweaked to try to make the different icons look a bit more visually appealing.