### PR TITLE
Run tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: tests
-on: push
+on: [push, pull_request]
 
 env:
   GO111MODULE: on


### PR DESCRIPTION
Currently, PRs from non-collaborators or collaborators who work in a fork don't have any tests running to check that their changes will work when merged. This change will trigger the testing workflow for pull requests from forks (no access to secrets).

#195 is an example of what happens without this change -- it is waiting indefinitely for the required gofmt and shellcheck checks, but they will never run.