### PR TITLE
updating docker compose for easier windows dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *.md
 .dockerignore
 .vvgo-config.json
+.google_api_credentials.json
 Dockerfile
 LICENSE

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 *.md
 .dockerignore
-CNAME
+.vvgo-config.json
 Dockerfile
 LICENSE
-fly.toml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,25 @@ services:
         published: 6379
         protocol: tcp
         mode: host
+
+  vvgo:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    ports:
+      - target: 8080
+        published: 8081
+        protocol: tcp
+        mode: host
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /etc/vvgo/google_api_credentials.json
+    volumes:
+      - type: bind
+        source: .vvgo-config.json
+        target: /etc/vvgo/config.json
+      - type: bind
+        source: .google_api_credentials.json
+        target: /etc/vvgo/google_api_credentials.json
+      - type: bind
+        source: ./public
+        target: /public


### PR DESCRIPTION
@Ranzha This is for you, so you don't need golang and yarn install to run vvgo.

With this, docker compose will build/launch vvgo for you in fewer commands.