### PR TITLE
Got rid of "Composed by" text

### DIFF
--- a/public/parts.gohtml
+++ b/public/parts.gohtml
@@ -56,7 +56,7 @@
     {{ end }}
     <div class="row row-cols-1">
         <div class="col text-center">
-            Composed by {{ .Composers }}<br/>
+            {{ .Composers }}<br/>
             <small>{{ .Arrangers }}</small>
         </div>
         <div class="col text-center">


### PR DESCRIPTION
This text isn't universal; soon, "Themes by" instead of "Composed by" applies to a particular arrangement. Let me know when this is implemented so I can pre-pend the composers line with "Composed by" where applicable.